### PR TITLE
Fix 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,35 +236,6 @@ jobs: # =====================================
     timeout-minutes: 5
 
     steps:
-      - name: 📊 Generate Final Report
-        run: |
-          echo "🎉 BUILD PIPELINE REPORT"
-          echo "========================================"
-          echo "📅 Date: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-          echo "🏷️  Run: #${{ github.run_number }}"
-          echo "🔗 Repository: ${{ github.repository }}"
-          echo "🌿 Branch: ${{ github.ref_name }}"
-          echo "👤 Triggered by: ${{ github.actor }}"
-          echo "⚡ Event: ${{ github.event_name }}"
-          echo ""          echo "📋 JOB STATUS SUMMARY:"
-          echo "========================================"
-          echo "🏗️  Build: ${{ needs.build.result }}"
-          echo "� Docker: ${{ needs.docker.result }}"
-          echo "�📦 Package: ${{ needs.package.result }}"
-          echo ""
-
-          # Determine overall status
-          if [[ "${{ needs.build.result }}" == "success" && 
-                "${{ needs.docker.result }}" == "success" && 
-                "${{ needs.package.result }}" == "success" ]]; then
-            echo "🎉 OVERALL STATUS: ✅ SUCCESS"
-            echo "🚀 Build completed successfully!"
-          else
-            echo "❌ OVERALL STATUS: ⚠️  FAILED"
-            echo "🔧 Please review failed jobs above"
-          fi
-          echo "========================================"
-
       - name: 💬 PR Comment (On Failure)
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v7


### PR DESCRIPTION
This pull request removes the "Generate Final Report" step from the CI workflow configuration file. The change simplifies the workflow by eliminating the custom reporting logic, which previously summarized job statuses and provided an overall build status.

### CI Workflow Changes:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL239-L267): Removed the "Generate Final Report" step, which included logic to display a summary of job statuses, overall build status, and other metadata like the repository, branch, and triggering actor.